### PR TITLE
Use isThere instead of fs.exists

### DIFF
--- a/src/js/application/host/system/systemhost.js
+++ b/src/js/application/host/system/systemhost.js
@@ -24,6 +24,7 @@
 
     var gui = require('nw.gui');
     var fs = require('fs');
+    var isThere = require('is-there');
 
     gui.App.on('open', function (cmdline) {
         if (cmdline && cmdline.length > 0) {
@@ -223,7 +224,7 @@
 
         var location = new URI(directory).filename(filename).path();
 
-        fs.exists(location, function (exists) {
+        isThere(location, function (exists) {
             if (!exists && createIfNotExists) {
                 done(location);
             } else if (exists) {


### PR DESCRIPTION
[`fs.exists` and `fs.existsSync` will be deprecated.](http://nodejs.org/api/fs.html#fs_fs_exists_path_callback)

I created [`is-there`](https://github.com/IonicaBizau/node-is-there), a tiny alternative to `fs.exists` and `fs.existsSync`.

Hope it helps. :smile: 